### PR TITLE
Add a toggle-able Grammalecte function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ of Grammalecte into your ~/.vimrc file using something like:
 
 ## Description ##
 
-The Grammalecte plugin defines 2 commands :GrammalecteCheck and
-:GrammalecteClean.
+The Grammalecte plugin defines 3 commands :GrammalecteCheck, :GrammalecteClean
+and :Grammalecte.
 
 	:GrammalecteCheck
 
@@ -82,6 +82,13 @@ The default range is 1,$ (whole buffer).
 Use the :GrammalecteClear command to clear highlighting of grammar
 mistakes, close the scratch window containing the list of errors, clear
 and close the location-list.
+
+	:Grammalecte
+
+Use the :Grammalecte command to toggle checking of grammar mistakes. It
+allows you to define toggle remap like:
+
+	nnoremap <Leader>tg :Grammalecte<Return>
 
 See  :help Grammalecte  for more details.
 

--- a/doc/Grammalecte.txt
+++ b/doc/Grammalecte.txt
@@ -164,10 +164,10 @@ colorscheme:
 
 6. Features                                           *grammalecte-features*
 
-The Grammalecte plugin defines 2 commands |:GrammalecteCheck| and
-|:GrammalecteClean|.
+The Grammalecte plugin defines 3 commands |:GrammalecteCheck|,
+|:GrammalecteClean| and |:Grammalecte|.
 
-:GrammalecteCheck                                         *:GrammalecteCheck*
+:GrammalecteCheck                                        *:GrammalecteCheck*
 
 Use the |:GrammalecteCheck| command to check the grammar in the current
 buffer. This will highlight errors in the buffer. It will also open a new
@@ -179,13 +179,20 @@ grammar between lines 100 and 200 in buffer with :100,200GrammalecteCheck,
 check grammar in the visual selection with :<',>'GrammalecteCheck, etc.
 The default range is 1,$ (whole buffer).
 
-:GrammalecteClear                                       *:GrammalecteClear*
+:GrammalecteClear                                        *:GrammalecteClear*
 
 Use the |:GrammalecteClear| command to clear highlighting of grammar
 mistakes, close the scratch window containing the list of errors, clear
 and close the location-list.
 
-The two commands are also available from the menu in gvim: >
+:Grammalecte                                                  *:Grammalecte*
+
+Use the |:Grammalecte| command to toggle checking of grammar mistakes. It
+allows you to define toggle remap like:
+
+  nnoremap <Leader>tg :Grammalecte<Return>
+
+The two main commands are also available from the menu in gvim: >
 
   Plugin -> Grammalecte -> Check
                         -> Clear

--- a/plugin/Grammalecte.vim
+++ b/plugin/Grammalecte.vim
@@ -302,6 +302,20 @@ function s:GrammalecteClear() "{{{1
   unlet! s:grammalecte_text_winid
 endfunction
 
+function s:Grammalecte(bang, line1, line2)
+  if a:bang
+    if exists('s:grammalecte_text_winid')
+      call s:GrammalecteClear()
+    endif
+  else
+    if exists('s:grammalecte_text_winid') == 0
+      call s:GrammalecteCheck(a:line1, a:line2)
+    else
+      call s:GrammalecteClear()
+    end
+  end
+endfunction
+
 hi def link GrammalecteCmd           Comment
 hi def link GrammalecteErrorCount    Title
 hi def link GrammalecteLabel         Label
@@ -319,4 +333,7 @@ endif
 com! -nargs=0          GrammalecteClear :call s:GrammalecteClear()
 com! -nargs=0 -range=% GrammalecteCheck :call s:GrammalecteCheck(<line1>,
                                                                \ <line2>)
+com! -nargs=0 -range=% -bar -bang Grammalecte :call s:Grammalecte(<bang>0,
+                                                                \ <line1>,
+                                                                \ <line2>)
 " vim: fdm=marker


### PR DESCRIPTION
Use the `:Grammalecte` command to toggle checking of grammar mistakes. It allows you to define toggle remap like:

```vim
nnoremap <Leader>tg :Grammalecte<Return>
```