### PR TITLE
Use grammalect-cli.py from PATH by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ this line in you ~/.vimrc:
 To use this plugin, you need to install the Python Grammalecte program.
 Grammalecte can be downloaded at:
 
-	http://www.dicollecte.org/grammalecte/telecharger.php
+	https://grammalecte.net/#download
 
 This vim plugin requires Grammalecte version 0.5.12 or newer.
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,16 @@ Grammalecte can be downloaded at:
 
 This vim plugin requires Grammalecte version 0.5.12 or newer.
 
-Unzip the Grammalecte-fr-v0.5.\*oxt file and specify the location
+Unzip the Grammalecte-fr-v0.5.\*zip file install it with:
+
+```
+pip3 install .
+```
+
+If you don't want to install it you can specify the location
 of Grammalecte into your ~/.vimrc file using something like:
 
-	let g:grammalecte_cli_py='~/Downloads/Grammalecte-fr-v0.5.14/pythonpath/cli.py'
+	let g:grammalecte_cmd='python3 ~/Downloads/Grammalecte-fr-v0.5.14/pythonpath/cli.py'
 
 ## Description ##
 

--- a/plugin/Grammalecte.vim
+++ b/plugin/Grammalecte.vim
@@ -58,22 +58,9 @@ function s:GrammalecteSetUp() "{{{1
   \ ? g:grammalecte_win_height
   \ : 14
 
-  let s:grammalecte_cli_py = exists("g:grammalecte_cli_py")
-  \ ? g:grammalecte_cli_py
-  \ : $HOME . '/grammalecte/pythonpath/cli.py'
-
-  if !filereadable(s:grammalecte_cli_py)
-    " Hmmm, can't find the python file.  Try again with expand() in case user
-    " set it up as: let g:python_cli_py = '$HOME/grammalecte/pythonpath/cli.py'
-    let l:grammalecte_cli_py = expand(s:grammalecte_cli_py)
-    if !filereadable(expand(l:grammalecte_cli_py))
-      echomsg "Grammalecte cannot be found at: " . s:grammalecte_cli_py
-      echomsg "You need to install Grammalecte and/or set up g:grammalecte_cli_py"
-      echomsg "to indicate the location of the Grammalecte pythonpath/cli.py script."
-      return -1
-    endif
-    let s:grammalecte_cli_py = l:grammalecte_cli_py
-  endif
+  let s:grammalecte_cmd = exists("g:grammalecte_cmd")
+  \ ? g:grammalecte_cmd
+  \ : 'grammalecte-cli.py'
 
 endfunction
 
@@ -147,7 +134,7 @@ function s:GrammalecteCheck(line1, line2) "{{{1
   let l:range = a:line1 . ',' . a:line2
   silent exe l:range . 'w!' . l:tmpfilename
 
-  let l:grammalecte_cmd = 'python3 ' . s:grammalecte_cli_py
+  let l:grammalecte_cmd = s:grammalecte_cmd
   \ . ' -f ' . l:tmpfilename
   \ . (empty(s:grammalecte_disable_rules) ? ' ' : (' -roff ' . s:grammalecte_disable_rules))
   \ . ' -j -cl -owe -ctx 2> ' . l:tmperror


### PR DESCRIPTION
It's easier to install grammalect python script by doing a simple
```
pip3 install .
```

Then `grammalect-cli.py` will be installed in `~/.local/bin` which can be added to $PATH.
After that vim-Grammalect can be installed without any modification of vim init script.